### PR TITLE
fix update voting test

### DIFF
--- a/decide/voting/models.py
+++ b/decide/voting/models.py
@@ -117,27 +117,28 @@ class Voting(models.Model):
 
     def do_postproc(self):
         tally = self.tally
-        options = self.question.options.all()
-
-        opts = []
-        for opt in options:
-            if self.type == 'IDENTITY':
-                votes = tally.count(opt.number)
-            elif self.type == 'DHONDT':
-                votes = tally.count(opt.number)
-            elif self.type == 'WEBSTER':
-                votes = tally.count(opt.number)    
-            else:
-                votes = 0
-            opts.append({
-                'option': opt.option,
-                'number': opt.number,
-                'votes': votes
-            })
-        data = { 'type': self.type, 'options': opts, 'seats': self.seats }
-        postp = mods.post('postproc', json=data)
-        self.postproc = postp
-        self.save()
+        if(type(tally) is list):
+            options = self.question.options.all()
+            opts = []
+            for opt in options:
+                if self.type == 'IDENTITY':
+                    votes = tally.count(opt.number)
+                elif self.type == 'DHONDT':
+                    votes = tally.count(opt.number)
+                elif self.type == 'WEBSTER':
+                    votes = tally.count(opt.number)    
+                else:
+                    votes = 0
+                opts.append({
+                    'option': opt.option,
+                    'number': opt.number,
+                    'votes': votes
+                })
+            data = { 'type': self.type, 'options': opts, 'seats': self.seats }
+            postp = mods.post('postproc', json=data)
+            self.postproc = postp
+            self.save()
+        
 
     def __str__(self):
         return self.name

--- a/decide/voting/tests.py
+++ b/decide/voting/tests.py
@@ -251,10 +251,10 @@ class VotingTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), 'Voting already stopped')
 
-        #data = {'action': 'tally'}
-        #response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
-        #self.assertEqual(response.status_code, 200)
-        #self.assertEqual(response.json(), 'Voting tallied')
+        data = {'action': 'tally'}
+        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), 'Voting tallied')
 
         # STATUS VOTING: tallied
         data = {'action': 'start'}
@@ -267,10 +267,10 @@ class VotingTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), 'Voting already stopped')
 
-        #data = {'action': 'tally'}
-        #response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
-        #self.assertEqual(response.status_code, 400)
-        #self.assertEqual(response.json(), 'Voting already tallied')
+        data = {'action': 'tally'}
+        response = self.client.put('/voting/{}/'.format(voting.pk), data, format='json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), 'Voting already tallied')
 
 class LogInSuccessTests(StaticLiveServerTestCase):
 


### PR DESCRIPTION
Se ha arreglado el fallo en el que al realizar el test test_update_voting, al intentar hacer tally cuando una votación estaba parada o ya se había hecho tally en ella saltaba una excepción.