### PR TITLE
Fix: Change register redirection

### DIFF
--- a/decide/users/templates/registration/register_fail.html
+++ b/decide/users/templates/registration/register_fail.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div style="text-align: center; margin-top: 20vh;">
+        <h2>Failed register</h2>
+        <h2>{{ error }}</h2>
+        <p>Redirecting to the form...</p>
+        <script>
+            setTimeout(function() {
+                window.location.href = "{% url 'users:register' %}";
+            }, 3000);
+        </script>
+    </div>
+{% endblock %}

--- a/decide/users/templates/registration/register_success.html
+++ b/decide/users/templates/registration/register_success.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+    <div style="text-align: center; margin-top: 20vh;">
+        <h2>Successfull register</h2>
+        <p>Redirecting to the main page...</p>
+        <script>
+            setTimeout(function() {
+                window.location.href = "{% url 'index' %}";
+            }, 2000);
+        </script>
+{% endblock %}

--- a/decide/users/views.py
+++ b/decide/users/views.py
@@ -37,19 +37,13 @@ class RegisterView(APIView):
         confirm_password = request.data.get('confirm_password', '')
         email = request.data.get('email', '') 
 
-        if not username or not password or not confirm_password:
-            return Response({'error': _('Username and password are required.')}, status=status.HTTP_400_BAD_REQUEST)
-        
         if password != confirm_password:
-            return Response({'error': _('The passwords do not match.')}, status=status.HTTP_400_BAD_REQUEST)
-        
+            return render(request, 'registration/register_fail.html', {'error': _('The passwords do not match.')})        
         try:
             user = User.objects.create_user(username, password=password, email=email)
-            token, created = Token.objects.get_or_create(user=user)
-            success_message = _('Successful registration. You are now registered.')
-            return Response({'user_pk': user.pk, 'token': token.key}, status=status.HTTP_201_CREATED)
+            return render(request, 'registration/register_success.html', {'message': _('Successful registration. You are now registered.')})        
         except IntegrityError:
-            return Response({'error': _('The username is already in use.')}, status=status.HTTP_400_BAD_REQUEST)
+            return render(request, 'registration/register_fail.html', {'error': _('The username is already in use.')})        
 
 
 


### PR DESCRIPTION
Se ha cambiado la redirección a la hora de registrarse para que sea más estético para los usuarios, usando htmls descriptivos en vez de la pantalla de response.

![Captura desde 2023-12-09 13-43-01](https://github.com/Decide-chiquito/decide-part-chiquito/assets/72499392/0bf291a8-f13e-4314-843e-3f1e1bc26b01)
![Captura desde 2023-12-09 13-42-45](https://github.com/Decide-chiquito/decide-part-chiquito/assets/72499392/3e94b592-2890-42b4-89b4-1629fb32166a)
![Captura desde 2023-12-09 13-42-32](https://github.com/Decide-chiquito/decide-part-chiquito/assets/72499392/1e453e63-3f0d-462c-a880-d17b5fbfa3bb)


Además, se han cambiado los tests para que realmente comprueben que funciona adecuadamente con la nueva redirección


![Captura desde 2023-12-09 13-43-48](https://github.com/Decide-chiquito/decide-part-chiquito/assets/72499392/892ab879-40e0-4657-8d3a-9ca8ab3df719)