### PR TITLE
Fix admin live statistics in list

### DIFF
--- a/decide/visualizer/templates/visualizer/listVisualizer.html
+++ b/decide/visualizer/templates/visualizer/listVisualizer.html
@@ -12,6 +12,9 @@
         <div class="info">
             </div class="row">    
                 <h2>{{visualizer.name}}</h2>
+                {% if visualizer.end_date == None  %}
+                    <p style="color: red;">Ver datos en directo</p>
+                {% endif %}
                 <a class="button"  href='/visualizer/{{visualizer.id}}'>{% trans 'Access'%}</a>       
             </div>
         </div>

--- a/decide/visualizer/views.py
+++ b/decide/visualizer/views.py
@@ -79,9 +79,16 @@ class VisualizerView(TemplateView):
     
     
 def listVisualizer(request):
-    if request.user.is_authenticated:
+    if request.user.is_superuser:
+        visualizers=[]
+        visualizerAll=Voting.objects.all()
+        for visualizer in visualizerAll:
+            if visualizer.start_date!= None:
+                visualizers.append(visualizer)
+        return render(request,'visualizer/listVisualizer.html',{'visualizers': visualizers})
+    elif request.user.is_authenticated:
         censos=Census.objects.filter(voter_id=request.user.id)
-        visualizers=[];
+        visualizers=[]
         for censo in censos:
             visualizerMyCenso=Voting.objects.filter(id=censo.voting_id)
             for visualizer in visualizerMyCenso:

--- a/decide/visualizer/views.py
+++ b/decide/visualizer/views.py
@@ -92,7 +92,7 @@ def listVisualizer(request):
         for censo in censos:
             visualizerMyCenso=Voting.objects.filter(id=censo.voting_id)
             for visualizer in visualizerMyCenso:
-                if visualizer.end_date!= None:
+                if visualizer.end_date is not None:
                     visualizers.append(visualizer)
         return render(request,'visualizer/listVisualizer.html',{'visualizers': visualizers})
     else:


### PR DESCRIPTION
Se han añadido a la lista de visualizer las votaciones con estadisticas en vivo

Ahora, cuando entras como admin en la lista completa, aparecen las que están en vivo: 
![image](https://github.com/Decide-chiquito/decide-part-chiquito/assets/72875687/43e150f4-d43c-4033-8255-352d80e3401d)
