### PR TITLE
Test: Digital certificate login in mobile

### DIFF
--- a/decide/users/static/users/style.css
+++ b/decide/users/static/users/style.css
@@ -163,6 +163,12 @@ a.btn-primary:link, a.btn-primary:visited {
     width: 60%;
 }
 
+.card-container-mobile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 @media (orientation: landscape) {
     .register-title-mobile, .edit-title-mobile {
         font-size: 50px;


### PR DESCRIPTION
Se han creado tests para comprobar el correcto funcionamiento de la funcionalidad de inicio de sesión con certificado digital a través de la interfaz para dispositivos móviles. En la imagen podemos ver como pasan todos los tests del módulo users donde se han incluido los nuevos tests.

![Tests certificado en móvil](https://github.com/Decide-chiquito/decide-part-chiquito/assets/73230994/6f385c03-7244-41cf-8980-b70ccfe18f0b)
